### PR TITLE
Here's the plan:

### DIFF
--- a/my-portfolio/public/serve.json
+++ b/my-portfolio/public/serve.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "**", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Add serve.json to fix client-side routing issues.

When you refreshed the page on any route other than the homepage, a 'Page not found' error would occur. This was because the development server (using 'serve') was not configured to handle client-side routing correctly for SPAs.

I'll add a `serve.json` file to the `public` directory. This file configures `serve` to rewrite all non-file requests to `/index.html`, allowing the client-side router (e.g., React Router) to handle the route.

The `serve.json` will be copied to the `build` directory during the `npm run build` process.

To use this configuration, you should serve the application with: `serve -s build -c build/serve.json`